### PR TITLE
Feature/mf shared buildable libs strict versioning

### DIFF
--- a/packages/angular/src/utils/mf/utils.ts
+++ b/packages/angular/src/utils/mf/utils.ts
@@ -103,7 +103,8 @@ export async function getModuleFederationConfig(
   }
 
   const sharedLibraries = shareWorkspaceLibraries(
-    dependencies.workspaceLibraries
+    dependencies.workspaceLibraries,
+    projectGraph
   );
 
   const npmPackages = sharePackages(
@@ -114,7 +115,8 @@ export async function getModuleFederationConfig(
           (pkg) => !DEFAULT_NPM_PACKAGES_TO_AVOID.includes(pkg)
         ),
       ])
-    )
+    ),
+    projectGraph.nodes[mfConfig.name]?.data
   );
 
   DEFAULT_NPM_PACKAGES_TO_AVOID.forEach((pkgName) => {

--- a/packages/devkit/src/utils/module-federation/package-json.ts
+++ b/packages/devkit/src/utils/module-federation/package-json.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'fs';
 import { requireNx } from '../../../nx';
+import type { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
 
 const { workspaceRoot, readJsonFile, joinPathFragments } = requireNx();
 
@@ -11,6 +12,21 @@ export function readRootPackageJson(): {
   if (!existsSync(pkgJsonPath)) {
     throw new Error(
       'NX MF: Could not find root package.json to determine dependency versions.'
+    );
+  }
+
+  return readJsonFile(pkgJsonPath);
+}
+
+// TODO: combine with prev fn
+export function readProjectPackageJson(project: ProjectConfiguration): {
+  dependencies?: { [key: string]: string };
+  devDependencies?: { [key: string]: string };
+} {
+  const pkgJsonPath = joinPathFragments(project.root, 'package.json');
+  if (!existsSync(pkgJsonPath)) {
+    throw new Error(
+      `NX MF: Could not find ${pkgJsonPath} to determine dependency versions.`
     );
   }
 

--- a/packages/devkit/src/utils/module-federation/public-api.ts
+++ b/packages/devkit/src/utils/module-federation/public-api.ts
@@ -22,7 +22,7 @@ import { mapRemotes, mapRemotesForSSR } from './remotes';
 
 import { getDependentPackagesForProject } from './dependencies';
 
-import { readRootPackageJson } from './package-json';
+import { readProjectPackageJson } from './package-json';
 
 export {
   /**
@@ -96,5 +96,5 @@ export {
   /**
    * @deprecated Accessing the Module Federation Utils from the Public API of @nx/devkit is deprecated and they will be removed from the Public API in v17.
    */
-  readRootPackageJson,
+  readProjectPackageJson as readRootPackageJson,
 };

--- a/packages/devkit/src/utils/module-federation/secondary-entry-points.ts
+++ b/packages/devkit/src/utils/module-federation/secondary-entry-points.ts
@@ -2,12 +2,13 @@ import type { WorkspaceLibrary } from './models';
 import { WorkspaceLibrarySecondaryEntryPoint } from './models';
 import { dirname, join, relative } from 'path';
 import { existsSync, lstatSync, readdirSync } from 'fs';
+import type { ProjectConfiguration } from 'nx/src/config/workspace-json-project-json';
 
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { PackageJson, readModulePackageJson } from 'nx/src/utils/package-json';
 import { requireNx } from '../../../nx';
 
-const { readJsonFile, joinPathFragments, workspaceRoot } = requireNx();
+const { readJsonFile, joinPathFragments, workspaceRoot, getNxRequirePaths } = requireNx();
 
 export function collectWorkspaceLibrarySecondaryEntryPoints(
   library: WorkspaceLibrary,
@@ -112,13 +113,17 @@ export function recursivelyCollectSecondaryEntryPointsFromDirectory(
 export function collectPackageSecondaryEntryPoints(
   pkgName: string,
   pkgVersion: string,
-  collectedPackages: { name: string; version: string }[]
+  collectedPackages: { name: string; version: string }[],
+  project: ProjectConfiguration
 ): void {
   let pathToPackage: string;
   let packageJsonPath: string;
   let packageJson: PackageJson;
   try {
-    ({ path: packageJsonPath, packageJson } = readModulePackageJson(pkgName));
+    ({ path: packageJsonPath, packageJson } = readModulePackageJson(pkgName), [
+      project.root,
+      ...getNxRequirePaths(),
+    ]);
     pathToPackage = dirname(packageJsonPath);
   } catch {
     // the package.json might not resolve if the package has the "exports"

--- a/packages/nx/src/devkit-exports.ts
+++ b/packages/nx/src/devkit-exports.ts
@@ -226,3 +226,8 @@ export { cacheDir } from './utils/cache-directory';
  * @category Utils
  */
 export { createProjectFileMapUsingProjectGraph } from './project-graph/file-map-utils';
+
+/**
+ * @category Utils
+ */
+export { getNxRequirePaths } from './utils/installation-directory';

--- a/packages/react/src/module-federation/utils.ts
+++ b/packages/react/src/module-federation/utils.ts
@@ -78,10 +78,11 @@ export async function getModuleFederationConfig(
   }
 
   const sharedLibraries = shareWorkspaceLibraries(
-    dependencies.workspaceLibraries
+    dependencies.workspaceLibraries,
+    projectGraph
   );
 
-  const npmPackages = sharePackages(dependencies.npmPackages);
+  const npmPackages = sharePackages(dependencies.npmPackages, project);
 
   const sharedDependencies = {
     ...sharedLibraries.getLibraries(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 overrides:
   minimist: ^1.2.6
@@ -5801,6 +5805,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.18
+    dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -6883,6 +6888,42 @@ packages:
       - typescript
     dev: true
 
+  /@nrwl/js@15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@15.8.0)(prettier@2.7.1)(typescript@5.1.3):
+    resolution: {integrity: sha512-l2Q7oFpzx6ul7G0nKpMkrvnIEaOY+X8fc2g2Db5WqpnnBdfkrtWXZPg/O4DQ1p9O6BXrZ+Q2AK9bfgnliiwyEg==}
+    dependencies:
+      '@babel/core': 7.22.5
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.22.5)
+      '@babel/plugin-proposal-decorators': 7.21.0(@babel/core@7.22.5)
+      '@babel/plugin-transform-runtime': 7.22.5(@babel/core@7.22.5)
+      '@babel/preset-env': 7.22.5(@babel/core@7.22.5)
+      '@babel/preset-typescript': 7.21.4(@babel/core@7.22.5)
+      '@babel/runtime': 7.22.5
+      '@nrwl/devkit': 15.8.0(nx@15.8.0)(typescript@5.1.3)
+      '@nrwl/workspace': 15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(prettier@2.7.1)(typescript@5.1.3)
+      '@phenomnomnominal/tsquery': 4.1.1(typescript@5.1.3)
+      babel-plugin-const-enum: 1.2.0(@babel/core@7.22.5)
+      babel-plugin-macros: 2.8.0
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.22.5)
+      chalk: 4.1.2
+      fast-glob: 3.2.7
+      fs-extra: 11.1.1
+      ignore: 5.2.0
+      js-tokens: 4.0.0
+      minimatch: 3.0.5
+      source-map-support: 0.5.19
+      tree-kill: 1.2.2
+      tslib: 2.5.3
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - debug
+      - nx
+      - prettier
+      - supports-color
+      - typescript
+    dev: true
+
   /@nrwl/js@16.5.0-beta.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@16.5.0-beta.0)(typescript@5.1.3)(verdaccio@5.15.4):
     resolution: {integrity: sha512-pEOPv/atGYWoP+AetXxQ5Is1TBakWPFUDSUw2IZXIhQtulkSNYs3DTQLGZdTHXc5voh4o/FScrbKL6ayCjdwAw==}
     dependencies:
@@ -6907,7 +6948,7 @@ packages:
         optional: true
     dependencies:
       '@nrwl/devkit': 15.8.0(nx@15.8.0)(typescript@5.1.3)
-      '@nrwl/js': 15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(eslint@8.15.0)(nx@16.5.0-beta.0)(prettier@2.7.1)(typescript@5.1.3)
+      '@nrwl/js': 15.8.0(@swc-node/register@1.5.4)(@swc/core@1.3.51)(nx@15.8.0)(prettier@2.7.1)(typescript@5.1.3)
       '@phenomnomnominal/tsquery': 4.1.1(typescript@5.1.3)
       eslint: 8.15.0
       tmp: 0.2.1
@@ -12633,6 +12674,7 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+    dev: true
 
   /buffer-indexof-polyfill@1.0.2:
     resolution: {integrity: sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==}
@@ -13205,6 +13247,7 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
 
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -23977,6 +24020,7 @@ packages:
       chokidar: 3.5.3
       immutable: 4.1.0
       source-map-js: 1.0.2
+    dev: true
 
   /sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}
@@ -24573,6 +24617,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
+    dev: true
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -25422,6 +25467,7 @@ packages:
       acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
+    dev: true
 
   /terser@5.18.0:
     resolution: {integrity: sha512-pdL757Ig5a0I+owA42l6tIuEycRuM7FPY4n62h44mRLRfnOxJkkOHd6i89dOpwZlpF6JXBwaAHF6yWzFrt+QyA==}
@@ -26508,7 +26554,7 @@ packages:
       mlly: 1.2.0
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.63.2)(stylus@0.59.0)(terser@5.17.7)
+      vite: 4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -26554,6 +26600,42 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /vite@4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.55.0)(stylus@0.59.0):
+    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.16.9
+      esbuild: 0.17.19
+      less: 4.1.3
+      postcss: 8.4.24
+      rollup: 3.21.0
+      sass: 1.55.0
+      stylus: 0.59.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
   /vite@4.3.9(@types/node@18.16.9)(less@4.1.3)(sass@1.63.2)(stylus@0.59.0)(terser@5.17.7):
     resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -26589,6 +26671,7 @@ packages:
       terser: 5.17.7
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vitest@0.32.0(less@4.1.3)(sass@1.55.0)(stylus@0.59.0):
     resolution: {integrity: sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==}
@@ -27565,7 +27648,3 @@ packages:
     dependencies:
       tslib: 2.5.3
     dev: true
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Current Behavior

* Only dependencies and devDependencies defined at `{workspaceRoot}/package.json` are shared with MF
* Buildable libs cannot have different versions at runtime due to MF Shared config

## Expected Behavior

* Dependencies and devDependencies from `{projectRoot}/package.json` and `{workspaceRoot}/package.json` are shared with MF
  * I noticed one edge case I still need to fix, but the general idea is clear
  * Main logic is [here](https://github.com/patricksevat/nx/pull/1/files#diff-10464bf9b44689e1a6559fdb9d4599343b648047b77abc6ae2c8f1faaa88f0f8R154-R172)
* Buildable libs now have different MF Shared configuration: `singleton: false` and `strictVersion: true`
  * Main logic is [here](https://github.com/patricksevat/nx/pull/1/files#diff-10464bf9b44689e1a6559fdb9d4599343b648047b77abc6ae2c8f1faaa88f0f8R85-R94)
  * Most likely we would like to have some sort of option on the `project.json` of either the app or buildable lib to enable this behavior

In the companion repo, I've created https://github.com/patricksevat/nx-buildable-lib-independent-deploys/pull/1/files

Using the instruction for [publishing to local repo](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#publishing-to-a-local-registry) I've published them locally under `16.5.0-postman`.

Can be installed with `npm install --registry http://localhost:4873`

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
