### PR TITLE
feat(vite): add generatePackageJsonVersionHash option which appends a…

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -37,6 +37,7 @@ export function createPackageJson(
     root?: string;
     isProduction?: boolean;
     helperDependencies?: string[];
+    versionHash?: string;
   } = {},
   fileMap: ProjectFileMap = null
 ): PackageJson {
@@ -171,6 +172,10 @@ export function createPackageJson(
   packageJson.peerDependenciesMeta &&= sortObjectByKeys(
     packageJson.peerDependenciesMeta
   );
+
+  if(options.versionHash) {
+    packageJson.version = `${packageJson.version}-${options.versionHash}`
+  }
 
   return packageJson;
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -33,6 +33,7 @@
     "@swc/helpers": "~0.5.0",
     "dotenv": "~10.0.0",
     "enquirer": "~2.3.6",
+    "fast-glob": "3.2.7",
     "@nx/devkit": "file:../devkit",
     "@nx/js": "file:../js"
   },

--- a/packages/vite/src/executors/build/schema.d.ts
+++ b/packages/vite/src/executors/build/schema.d.ts
@@ -16,6 +16,7 @@ export interface ViteBuildExecutorOptions {
   watch?: object | boolean;
   target?: string | string[];
   generatePackageJson?: boolean;
+  generatePackageJsonVersionHash?: boolean;
   includeDevDependenciesInPackageJson?: boolean;
   cssCodeSplit?: boolean;
   buildLibsFromSource?: boolean;

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -158,6 +158,9 @@
       "description": "Generate a package.json for the build output.",
       "type": "boolean"
     },
+    "generatePackageJsonVersionHash": {
+      "description": "Append a hash to the {outputPath}/package.json version, based on the generated .d.ts files"
+    },
     "includeDevDependenciesInPackageJson": {
       "description": "Include devDependencies in the generated package.json.",
       "type": "boolean"


### PR DESCRIPTION
… hash based on {outputPath}/**/*.d.ts files to {outputPath}/package.json version

## Current Behavior

* {projectRoot}/package.json is copied over to {outputPath}/package.json when using buildable libs
* {projectRoot}/package.json is constructed and written to {outputPath}/package.json when using `"generatePackageJson": true`

## Expected Behavior

* {projectRoot}/package.json is copied over to {outputPath}/package.json when using buildable libs
* [NEW] {projectRoot}/package.json is copied over to {outputPath}/package.json and `version` gets appended hash when using buildable libs and `"generatePackageJsonVersionHash": true`
* {projectRoot}/package.json is constructed and written to {outputPath}/package.json when using `"generatePackageJson": true`
* [NEW] {projectRoot}/package.json is constructed and written to {outputPath}/package.json and `version` gets appended hash when using `"generatePackageJson": true` and `"generatePackageJsonVersionHash": true

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #


**Note**

This is a follow up PR to https://github.com/patricksevat/nx/pull/1